### PR TITLE
Knowing about whereabouts

### DIFF
--- a/actions/eval.go
+++ b/actions/eval.go
@@ -71,9 +71,18 @@ func Eval(c *cli.Context) error {
 
 	// save tagged outputs
 	for outputName, output := range frm.Outputs {
-		if output.Tag != "" {
-			p.PutResult(output.Tag, outputName, &rr)
+		if output.Tag == "" {
+			continue
 		}
+		p.PutResult(output.Tag, outputName, &rr)
+	}
+
+	// memorize all the warehouses that were listed as destinations for outputs
+	for outputName, output := range frm.Outputs {
+		if output.Tag == "" {
+			continue
+		}
+		p.AppendWarehouseForWare(rr.Results[outputName].Ware, output.Warehouses)
 	}
 
 	p.WriteFile(".reppl")

--- a/actions/eval.go
+++ b/actions/eval.go
@@ -120,6 +120,16 @@ func createPinnedFormula(p *model.Project, frm rdef.Formula) rdef.Formula {
 			}
 		}
 	}
+	// append any warehouses we know of
+	for _, input := range frm.Inputs {
+		ware := rdef.Ware{input.Type, input.Hash}
+		moreWarehouseCoords, err := p.GetWarehousesByWare(ware)
+		if err != nil {
+			// nbd if we don't have any.  hope the formula had some of its own; but if not, that error isn't for our layer to raise.
+			continue
+		}
+		input.Warehouses = append(input.Warehouses, moreWarehouseCoords...)
+	}
 	return frm
 }
 

--- a/actions/put.go
+++ b/actions/put.go
@@ -13,6 +13,8 @@ import (
 func PutHash(c *cli.Context) error {
 	tag := c.Args().Get(0)
 	hash := c.Args().Get(1)
+	warehouseStrArg_isSet := c.IsSet("warehouse")
+	warehouseStr := c.String("warehouse")
 
 	p := model.FromFile(".reppl")
 	ware := rdef.Ware{
@@ -20,6 +22,12 @@ func PutHash(c *cli.Context) error {
 		Hash: hash,
 	}
 	p.PutManualTag(tag, ware)
+	if warehouseStrArg_isSet {
+		p.AppendWarehouseForWare(
+			ware,
+			rdef.WarehouseCoords{rdef.WarehouseCoord(warehouseStr)},
+		)
+	}
 	p.WriteFile(".reppl")
 	fmt.Printf(
 		"%s %s %s %s %s\n",

--- a/actions/unpack.go
+++ b/actions/unpack.go
@@ -1,0 +1,86 @@
+package actions
+
+import (
+	"fmt"
+	"os"
+
+	. "github.com/polydawn/gosh"
+	"github.com/urfave/cli"
+	rdef "go.polydawn.net/repeatr/api/def"
+
+	"go.polydawn.net/reppl/lib/efmt"
+	"go.polydawn.net/reppl/model"
+)
+
+func Unpack(c *cli.Context) error {
+	// Fathom args.
+	tag := c.Args().Get(0)
+	unpackPath := c.Args().Get(1)
+	warehouseArgStr_isSet := c.IsSet("warehouse")
+	warehouseArgStr := c.String("warehouse") // Optional and usually unneeded because our model may also cache warehouses.
+
+	// Load model of project.
+	// It should know about the tag and resolve us a ware hash.
+	proj := model.FromFile(".reppl")
+	ware, err := proj.GetWareByTag(tag)
+	if err != nil {
+		panic(err)
+	}
+
+	// Figure out what warehouseCoords to use, and munge to correct struct.
+	// If the was a command line given, prefer that;
+	// otherwise, check for one in the project model;
+	// if none, we cannot proceed.
+	// TODO verify this, actually.  Maybe your cache has it and we can live on that.
+	var warehouseCoords rdef.WarehouseCoords
+	if warehouseArgStr_isSet {
+		warehouseCoords = rdef.WarehouseCoords{rdef.WarehouseCoord(warehouseArgStr)}
+	} else {
+		warehouseCoords, err = proj.GetWarehousesByWare(ware)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	// Fire all lasers.
+	invokeRepeatrUnpack(
+		ware,
+		unpackPath,
+		warehouseCoords,
+		false,
+	)
+
+	// Confess to our sins.
+	fmt.Printf(
+		"%s %s %s %s %s %s %s\n",
+		efmt.AnsiWrap("reppl unpack", efmt.Ansi_textBrightYellow),
+		efmt.AnsiWrap("tag:", efmt.Ansi_textYellow),
+		efmt.AnsiWrap(tag, efmt.Ansi_textYellow, efmt.Ansi_underline),
+		efmt.AnsiWrap("=", efmt.Ansi_textYellow),
+		efmt.AnsiWrap(ware.Hash, efmt.Ansi_textYellow, efmt.Ansi_underline),
+		efmt.AnsiWrap("to", efmt.Ansi_textYellow),
+		efmt.AnsiWrap(unpackPath, efmt.Ansi_textYellow, efmt.Ansi_underline),
+	)
+	return nil
+}
+
+func invokeRepeatrUnpack(ware rdef.Ware, placePath string, warehouseCoords rdef.WarehouseCoords, skipExists bool) {
+	outstrm := efmt.LinePrefixingWriter(
+		os.Stderr,
+		efmt.AnsiWrap("│ reppl eval >\t", efmt.Ansi_textBrightPurple),
+	)
+	cmd := Gosh("repeatr", "unpack",
+		"--hash", ware.Hash,
+		"--kind", ware.Type,
+		"--place", placePath,
+		"--where", string(warehouseCoords[0]),
+		Opts{
+			Out: outstrm,
+			Err: outstrm,
+		},
+	).Bake()
+	if skipExists {
+		cmd = cmd.Bake("--skip-exists")
+	}
+	cmd.Run()
+}

--- a/cmd/reppl/main.go
+++ b/cmd/reppl/main.go
@@ -18,6 +18,12 @@ func main() {
 				{
 					Name:   "hash",
 					Action: actions.PutHash,
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "warehouse",
+							Usage: "A URL giving coordinates to a warehouse where we should be able to find this ware.",
+						},
+					},
 				},
 				{
 					Name:   "file",

--- a/cmd/reppl/main.go
+++ b/cmd/reppl/main.go
@@ -43,7 +43,16 @@ func main() {
 			Name:   "show",
 			Action: actions.Show,
 		},
-
+		{
+			Name:   "unpack",
+			Action: actions.Unpack,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "warehouse",
+					Usage: "Optional -- A URL giving coordinates to a warehouse where we should be able to find this ware.",
+				},
+			},
+		},
 		{
 			Name:   "rm",
 			Action: actions.Remove,

--- a/demo/.gitignore
+++ b/demo/.gitignore
@@ -1,0 +1,11 @@
+## ignore wares produced in the pipeline.  they're binary artifacts and may be large!
+/wares/
+
+## ignore any debug unpacks.  we're just showing off; they're reproducible.
+/debug/
+
+## ignore the reppl state.  you could commit this, but the demo is entirely reproducible.
+/.reppl
+
+## ignore any pinned formulas.  we can reproduce them as well (the templates are committed).
+/*.frm.pin

--- a/demo/step-A.frm
+++ b/demo/step-A.frm
@@ -1,0 +1,19 @@
+inputs:
+	"/":
+		tag:  "base"
+		silo:
+			- "file+ca://./wares/"
+			- "http+ca://repeatr.s3.amazonaws.com/assets/"
+action:
+	command:
+		- "/bin/bash"
+		- "-c"
+		- |
+			set -euo pipefail ; set -x
+			mkdir output
+			echo "wheeeee asset A" > output/wow
+outputs:
+	"/task/output":
+		tag: "asset-A"
+		type: "tar"
+		silo: "file+ca://./wares/"

--- a/demo/step-B.frm
+++ b/demo/step-B.frm
@@ -1,0 +1,29 @@
+inputs:
+	"/":
+		tag:  "base"
+		silo:
+			- "file+ca://./wares/"
+			- "http+ca://repeatr.s3.amazonaws.com/assets/"
+	"/lib/asset-A":
+		tag:  "asset-A"
+		silo: "file+ca://./wares/"
+action:
+	command:
+		- "/bin/bash"
+		- "-c"
+		- |
+			set -euo pipefail ; set -x
+			mkdir -p output/one output/two
+			cp -a /lib/asset-A output/one/lib-A
+			cp -a /lib/asset-A output/two/lib-A
+			echo "+processB1" > output/one/b.sh
+			echo "+processB2" > output/two/b.sh
+outputs:
+	"/task/output/one":
+		tag: "asset-B1"
+		type: "tar"
+		silo: "file+ca://./wares/"
+	"/task/output/two":
+		tag: "asset-B2"
+		type: "tar"
+		silo: "file+ca://./wares/"

--- a/demo/step-G.frm
+++ b/demo/step-G.frm
@@ -1,0 +1,28 @@
+inputs:
+	"/":            {tag: "base"}
+	"/lib/asset-A": {tag: "asset-A"}
+	"/app/go":      {tag: "go"}
+action:
+	command:
+		- "/bin/bash"
+		- "-c"
+		- |
+			set -euo pipefail ; set -x
+			export PATH="$PATH:/app/go/go/bin"
+			export GOROOT="/app/go/go"
+			cat >main.go <<EOF
+				package main
+				
+				import "fmt"
+				
+				func main() {
+					fmt.Println("Hello, 世界")
+				}
+			EOF
+			mkdir bin
+			go build -o bin/hello .
+outputs:
+	"/task/bin":
+		tag: "hellogopher"
+		type: "tar"
+		silo: "file+ca://./wares/"

--- a/demo/whee.sh
+++ b/demo/whee.sh
@@ -1,9 +1,10 @@
 mkdir -p wares
 mkdir -p debug
 reppl init
-reppl  put hash base  aLMH4qK1EdlPDavdhErOs0BPxqO0i6lUaeRE4DuUmnNMxhHtF56gkoeSulvwWNqT
+reppl  put hash base  aLMH4qK1EdlPDavdhErOs0BPxqO0i6lUaeRE4DuUmnNMxhHtF56gkoeSulvwWNqT  --warehouse=http+ca://repeatr.s3.amazonaws.com/assets/
 #reppl put hash go    sZOo52xMYaezehGNWm5c7W9bLNTIxGtybW_TAUzMeoKA--o2dtxusu5dYsTct2cV  --warehouse=https://storage.googleapis.com/golang/go1.7.1.linux-amd64.tar.gz
 reppl  put hash go    UoY1amg4W8_JVQJ6tg6I4BQm1Mlw3ngT_kutZNr6XfFvvWAZfGrwDxDcQD2TzOVz  --warehouse=https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz
 reppl eval step-A.frm
 reppl eval step-B.frm
-#reppl unpack go debug/go ## don't actually do this because the `go build` command for reppl will try to build the stdlib XD
+reppl eval step-G.frm
+reppl unpack hellogopher debug/hellogopher

--- a/demo/whee.sh
+++ b/demo/whee.sh
@@ -1,0 +1,9 @@
+mkdir -p wares
+mkdir -p debug
+reppl init
+reppl  put hash base  aLMH4qK1EdlPDavdhErOs0BPxqO0i6lUaeRE4DuUmnNMxhHtF56gkoeSulvwWNqT
+#reppl put hash go    sZOo52xMYaezehGNWm5c7W9bLNTIxGtybW_TAUzMeoKA--o2dtxusu5dYsTct2cV  --warehouse=https://storage.googleapis.com/golang/go1.7.1.linux-amd64.tar.gz
+reppl  put hash go    UoY1amg4W8_JVQJ6tg6I4BQm1Mlw3ngT_kutZNr6XfFvvWAZfGrwDxDcQD2TzOVz  --warehouse=https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz
+reppl eval step-A.frm
+reppl eval step-B.frm
+#reppl unpack go debug/go ## don't actually do this because the `go build` command for reppl will try to build the stdlib XD

--- a/model/model.go
+++ b/model/model.go
@@ -26,6 +26,7 @@ func (p *Project) Init() {
 	p.Tags = make(map[string]ReleaseRecord)
 	p.RunRecords = make(map[string]*rdef.RunRecord)
 	p.Memos = make(map[string]string)
+	p.Whereabouts = make(map[rdef.Ware]rdef.WarehouseCoords)
 }
 
 func (p *Project) WriteFile(filename string) {

--- a/model/model.go
+++ b/model/model.go
@@ -71,7 +71,7 @@ func (p *Project) PutManualTag(tag string, ware rdef.Ware) {
 	}
 }
 
-func (p *Project) PutManualWarehouse(ware rdef.Ware, moreCoords rdef.WarehouseCoords) {
+func (p *Project) AppendWarehouseForWare(ware rdef.Ware, moreCoords rdef.WarehouseCoords) {
 	coords, _ := p.Whereabouts[ware]
 	p.Whereabouts[ware] = append(coords, moreCoords...)
 }

--- a/model/model.go
+++ b/model/model.go
@@ -74,7 +74,20 @@ func (p *Project) PutManualTag(tag string, ware rdef.Ware) {
 
 func (p *Project) AppendWarehouseForWare(ware rdef.Ware, moreCoords rdef.WarehouseCoords) {
 	coords, _ := p.Whereabouts[ware]
-	p.Whereabouts[ware] = append(coords, moreCoords...)
+	// Append, putting the most recent ones first.
+	coords = append(moreCoords, coords...)
+	// Filter out any duplicates.
+	set := make(map[rdef.WarehouseCoord]struct{})
+	n := 0
+	for i, v := range coords {
+		_, exists := set[v]
+		if exists {
+			continue // leave it behind
+		}
+		set[v] = struct{}{}
+		coords[n] = coords[i]
+	}
+	p.Whereabouts[ware] = coords[0 : n+1]
 }
 
 func (p *Project) DeleteTag(tag string) {

--- a/model/model.go
+++ b/model/model.go
@@ -98,7 +98,7 @@ func (p *Project) GetWarehousesByWare(ware rdef.Ware) (rdef.WarehouseCoords, err
 	if exists {
 		return coords, nil
 	} else {
-		return nil, errors.New("not found")
+		return nil, fmt.Errorf("no warehouses known for ware %s:%s", ware.Type, ware.Hash)
 	}
 }
 


### PR DESCRIPTION
Reppl now keeps information about warehouses that should be apply to supply wares.

This info is indexed by ware hash and retained for any wares that are tagged (it's subject to the same instant-gc when it becomes unreferenced as everything else).

There is now a `reppl unpack` command that DTRT, letting you provide a tag name for an asset you want unpacked on the local filesystem, and doing it.  This lets you get results out of one of your pipelines and instantly start using it on your host, which is... kinda awesome.  Was definitely a missing piece before.

You can provide warehouse coordinates when inserting hashes manually, and they're also collected automatically from formulas that reppl eval's.  Warehouses that reppl remembers are also automatically appended to formulas.  The net result is you can now write most formulas without bothering to specify warehouses for any of the inputs at all -- you can usually get away with *just tags*, because the transport type, ware hash, and warehouse coords will *all* be subbed in automatically.

Practically speaking, this also means when referencing external wares with upstream storage that's legacy / non-content-addressable, you can state both the hash and upstream URL on the same `reppl put` line... so updating references to new versions is WAY smoother.  Previously you'd generally have to change the hash in the `reppl put` line, and also change the URL (e.g. to adjust the version number in that string) in every formula that referenced it, which was kinda awful; now it's smooth.