### PR TITLE
Teach the 'reppl put' command to accept a kind flag.

### DIFF
--- a/actions/put.go
+++ b/actions/put.go
@@ -15,27 +15,39 @@ func PutHash(c *cli.Context) error {
 	hash := c.Args().Get(1)
 	warehouseStrArg_isSet := c.IsSet("warehouse")
 	warehouseStr := c.String("warehouse")
+	kindStrArg_isSet := c.IsSet("kind")
+	kindStr := c.String("kind")
 
 	p := model.FromFile(".reppl")
+
+	wareType := "tar"
+	if kindStrArg_isSet {
+		wareType = kindStr
+	}
 	ware := rdef.Ware{
-		Type: "tar",
+		Type: wareType,
 		Hash: hash,
 	}
 	p.PutManualTag(tag, ware)
+
 	if warehouseStrArg_isSet {
 		p.AppendWarehouseForWare(
 			ware,
 			rdef.WarehouseCoords{rdef.WarehouseCoord(warehouseStr)},
 		)
 	}
+
 	p.WriteFile(".reppl")
+
 	fmt.Printf(
-		"%s %s %s %s %s\n",
+		"%s %s %s %s %s%s%s\n",
 		efmt.AnsiWrap("reppl put", efmt.Ansi_textBrightYellow),
 		efmt.AnsiWrap("hash:", efmt.Ansi_textYellow),
 		efmt.AnsiWrap(tag, efmt.Ansi_textYellow, efmt.Ansi_underline),
 		efmt.AnsiWrap("=", efmt.Ansi_textYellow),
-		efmt.AnsiWrap(hash, efmt.Ansi_textYellow, efmt.Ansi_underline),
+		efmt.AnsiWrap(ware.Type, efmt.Ansi_textYellow, efmt.Ansi_underline),
+		efmt.AnsiWrap(":", efmt.Ansi_textYellow),
+		efmt.AnsiWrap(ware.Hash, efmt.Ansi_textYellow, efmt.Ansi_underline),
 	)
 	return nil
 }

--- a/cmd/reppl/main.go
+++ b/cmd/reppl/main.go
@@ -23,6 +23,10 @@ func main() {
 							Name:  "warehouse",
 							Usage: "A URL giving coordinates to a warehouse where we should be able to find this ware.",
 						},
+						cli.StringFlag{
+							Name:  "kind",
+							Usage: "The kind of transit format this ware is.  Defaults to tar if unspecified.",
+						},
 					},
 				},
 				{


### PR DESCRIPTION
Teach the 'reppl put' command to accept a kind flag.

This makes it possible to use it correctly for e.g. plain-file transport, or git transport... even for unpack.  

(You could already specify the type of transport in a formula, and reppl wouldn't override it, which already made it possible to work with git etc in eval; this is also less clumsy and odd looking than that, of course, and has the database in the reppl state file less wrong.)
