### PR TITLE
Allow eval to inject environment variables

### DIFF
--- a/actions/eval.go
+++ b/actions/eval.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
+	"strings"
 
 	. "github.com/polydawn/gosh"
 	"github.com/ugorji/go/codec"
@@ -31,6 +32,16 @@ func Eval(c *cli.Context) error {
 	// decode the formula file into a formula
 	var frm rdef.Formula
 	rhitch.DecodeYaml(f, &frm)
+
+	envVars := c.StringSlice("environment")
+	for _, item := range envVars {
+		splits := strings.SplitN(item, "=", 2)
+		if len(splits) != 2 {
+			panic(fmt.Sprintf("Invalid environment variable '%s' must be of format 'NAME=VALUE'", item))
+		}
+		// inject environment variable into formula
+		frm.Action.Env[splits[0]] = splits[1]
+	}
 
 	// get our project definition
 	p := model.FromFile(".reppl")

--- a/cmd/reppl/main.go
+++ b/cmd/reppl/main.go
@@ -38,6 +38,12 @@ func main() {
 		{
 			Name:   "eval",
 			Action: actions.Eval,
+			Flags: []cli.Flag{
+				cli.StringSliceFlag{
+					Name:  "env, e",
+					Usage: "Apply additional environment vars to formula before launch.  Format like '-e KEY=val'",
+				},
+			},
 		},
 		{
 			Name:   "init",


### PR DESCRIPTION
This will give the 'eval' command the ability to add or modify
formula environment variables via '--environment' or '-e'.
This will allow things such as modifying the GITCOMMIT variable
when building repeatr for injection into the build.

Signed-off-by: Calvin Behling <calvin.behling@gmail.com>