### PR TITLE
Fix flag lookup for eval environment injection

### DIFF
--- a/actions/eval.go
+++ b/actions/eval.go
@@ -33,7 +33,7 @@ func Eval(c *cli.Context) error {
 	var frm rdef.Formula
 	rhitch.DecodeYaml(f, &frm)
 
-	envVars := c.StringSlice("environment")
+	envVars := c.StringSlice("env")
 	for _, item := range envVars {
 		splits := strings.SplitN(item, "=", 2)
 		if len(splits) != 2 {


### PR DESCRIPTION
Forgot to change the lookup string to match the flag name.
