### PR TITLE
Add '-f'/'--force' option to `reppl eval`.

### DIFF
--- a/cmd/reppl/main.go
+++ b/cmd/reppl/main.go
@@ -40,6 +40,10 @@ func main() {
 			Name:   "eval",
 			Action: actions.Eval,
 			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "force, f",
+					Usage: "Optional -- Force this formula to *always* be run, even if we have a memoized result for its current setup.",
+				},
 				cli.StringSliceFlag{
 					Name:  "env, e",
 					Usage: "Apply additional environment vars to formula before launch.  Format like '-e KEY=val'",


### PR DESCRIPTION
Add '-f'/'--force' option to `reppl eval`, which causes reppl to *always* run the formula, even if it has memoized results.

This is often useful if debugging something in the middle of a big pipeline: clearly throwing away the whole `.reppl` statefile would be a waste of time, but just one step reeeeeally needs a closer look or a re-run because (god forbid) it's doing something networked and it had an unusual failure.