### PR TITLE
Adds error exit code to reppl eval

### DIFF
--- a/demo/exit-code-test.frm
+++ b/demo/exit-code-test.frm
@@ -1,0 +1,14 @@
+inputs:
+	"/":
+		type: "tar"
+		hash: "uJRF46th6rYHt0zt_n3fcDuBfGFVPS6lzRZla5hv6iDoh5DVVzxUTMMzENfPoboL"
+		silo: "http+ca://repeatr.s3.amazonaws.com/assets/"
+action:
+  env:
+    EXIT_CODE: "1"
+	command:
+		- "/bin/bash"
+		- "-c"
+		- |
+			set -euo pipefail
+			exit ${EXIT_CODE}


### PR DESCRIPTION
If the executed formula exits with a non-zero exit code
then 'reppl eval' should also have a non-zero exit code.
This enables the user to handle formula eval failures.

Signed-off-by: Calvin Behling <calvin.behling@gmail.com>